### PR TITLE
Fix CoordinatorLayout NullPointerException in onTouchEvent.

### DIFF
--- a/app/src/main/java/com/antonioleiva/materializeyourapp/DetailActivity.java
+++ b/app/src/main/java/com/antonioleiva/materializeyourapp/DetailActivity.java
@@ -31,6 +31,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.graphics.Palette;
 import android.support.v7.widget.Toolbar;
 import android.transition.Slide;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -88,6 +89,14 @@ public class DetailActivity extends AppCompatActivity {
 
         TextView title = (TextView) findViewById(R.id.title);
         title.setText(itemTitle);
+    }
+
+    @Override public boolean dispatchTouchEvent(MotionEvent motionEvent) {
+        try {
+            return super.dispatchTouchEvent(motionEvent);
+        } catch (NullPointerException e) {
+            return false;
+        }
     }
 
     private void initActivityTransitions() {


### PR DESCRIPTION
Summary:
On some devices, a touch event triggered while the toolbar is half-way
collapsed, causes a NullPointerException.

This issue was detected after upgrading the support libraries to version 23 and
reported at Android Open Source Project issue tracker. For more information,
please check https://code.google.com/p/android/issues/detail?id=183166.
