### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ After that, I've used this example in some other articles:
 
 [More info and tutorials @ antonioleiva.com](http://antonioleiva.com/)
 
-#License
+# License
 
     Copyright 2015 Antonio Leiva
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
